### PR TITLE
Color request.py

### DIFF
--- a/urllib3/_async/connectionpool.py
+++ b/urllib3/_async/connectionpool.py
@@ -27,7 +27,7 @@ from ..exceptions import (
 from urllib3.packages.ssl_match_hostname import CertificateError
 from urllib3.packages import six
 from urllib3.packages.six.moves import queue
-from ..request import RequestMethods
+from .request import RequestMethods
 from .response import HTTPResponse
 from .connection import HTTP1Connection
 

--- a/urllib3/_async/poolmanager.py
+++ b/urllib3/_async/poolmanager.py
@@ -8,7 +8,7 @@ from ..base import DEFAULT_PORTS
 from .connectionpool import HTTPConnectionPool, HTTPSConnectionPool
 from ..exceptions import LocationValueError, MaxRetryError, ProxySchemeUnknown
 from ..packages.six.moves.urllib.parse import urljoin
-from ..request import RequestMethods
+from .request import RequestMethods
 from ..util.url import parse_url
 from ..util.request import set_file_position
 from ..util.retry import Retry

--- a/urllib3/_async/request.py
+++ b/urllib3/_async/request.py
@@ -1,8 +1,8 @@
 from __future__ import absolute_import
 
-from .filepost import encode_multipart_formdata
-from .packages import six
-from .packages.six.moves.urllib.parse import urlencode
+from ..filepost import encode_multipart_formdata
+from ..packages import six
+from ..packages.six.moves.urllib.parse import urlencode
 
 
 __all__ = ['RequestMethods']
@@ -42,13 +42,14 @@ class RequestMethods(object):
     def __init__(self, headers=None):
         self.headers = headers or {}
 
-    def urlopen(self, method, url, body=None, headers=None,
-                encode_multipart=True, multipart_boundary=None,
-                **kw):  # Abstract
+    async def urlopen(self, method, url, body=None, headers=None,
+                      encode_multipart=True, multipart_boundary=None,
+                      **kw):  # Abstract
         raise NotImplementedError("Classes extending RequestMethods must implement "
                                   "their own ``urlopen`` method.")
 
-    def request(self, method, url, fields=None, headers=None, **urlopen_kw):
+    async def request(self, method, url, fields=None, headers=None,
+                      **urlopen_kw):
         """
         Make a request using :meth:`urlopen` with the appropriate encoding of
         ``fields`` based on the ``method`` used.
@@ -62,16 +63,16 @@ class RequestMethods(object):
         method = method.upper()
 
         if method in self._encode_url_methods:
-            return self.request_encode_url(method, url, fields=fields,
-                                           headers=headers,
-                                           **urlopen_kw)
+            return await self.request_encode_url(method, url, fields=fields,
+                                                 headers=headers,
+                                                 **urlopen_kw)
         else:
-            return self.request_encode_body(method, url, fields=fields,
-                                            headers=headers,
-                                            **urlopen_kw)
+            return await self.request_encode_body(method, url, fields=fields,
+                                                  headers=headers,
+                                                  **urlopen_kw)
 
-    def request_encode_url(self, method, url, fields=None, headers=None,
-                           **urlopen_kw):
+    async def request_encode_url(self, method, url, fields=None, headers=None,
+                                 **urlopen_kw):
         """
         Make a request using :meth:`urlopen` with the ``fields`` encoded in
         the url. This is useful for request methods like GET, HEAD, DELETE, etc.
@@ -85,11 +86,11 @@ class RequestMethods(object):
         if fields:
             url += '?' + urlencode(fields)
 
-        return self.urlopen(method, url, **extra_kw)
+        return await self.urlopen(method, url, **extra_kw)
 
-    def request_encode_body(self, method, url, fields=None, headers=None,
-                            encode_multipart=True, multipart_boundary=None,
-                            **urlopen_kw):
+    async def request_encode_body(self, method, url, fields=None,
+                                  headers=None, encode_multipart=True,
+                                  multipart_boundary=None, **urlopen_kw):
         """
         Make a request using :meth:`urlopen` with the ``fields`` encoded in
         the body. This is useful for request methods like POST, PUT, PATCH, etc.
@@ -149,4 +150,4 @@ class RequestMethods(object):
         extra_kw['headers'].update(headers)
         extra_kw.update(urlopen_kw)
 
-        return self.urlopen(method, url, **extra_kw)
+        return await self.urlopen(method, url, **extra_kw)

--- a/urllib3/contrib/appengine.py
+++ b/urllib3/contrib/appengine.py
@@ -54,7 +54,7 @@ from ..exceptions import (
 )
 
 from ..packages.six import BytesIO
-from ..request import RequestMethods
+from .._sync.request import RequestMethods
 from ..response import HTTPResponse
 from ..util.timeout import Timeout
 from ..util.retry import Retry

--- a/urllib3/request.py
+++ b/urllib3/request.py
@@ -1,0 +1,3 @@
+from ._sync.request import RequestMethods
+
+__all__ = ['RequestMethods']


### PR DESCRIPTION
It turns out that the async connection pools and pool managers use this
code, but it worked because `return await f()` is not an error and
because RequestMethods simply returns the values it receives.