### PR TITLE
Tell Windows codecov the file to upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,4 +35,4 @@ jobs:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       run: |
         python.exe -m pip install codecov
-        python.exe -m codecov
+        python.exe -m codecov -f coverage.xml


### PR DESCRIPTION
Hopefully this will improve the coverage as codecov was not finding the coverage file on Windows so it simply was not uploaded.