### PR TITLE
Add Request and RequestData APIs

### DIFF
--- a/src/hip/_async/models.pyi
+++ b/src/hip/_async/models.pyi
@@ -28,3 +28,5 @@ class RequestData:
         If the internal data is not rewindable and this function is called
         then a 'hip.UnrewindableBodyError' is raised.
         """
+    @property
+    def content_type(self) -> str: ...

--- a/src/hip/_async/models.pyi
+++ b/src/hip/_async/models.pyi
@@ -1,0 +1,30 @@
+import typing
+
+class RequestData:
+    """Represents a synchronous request data object. Basically a wrapper around whatever
+    a user passes in via 'data', 'files', 'json', etc parameters. We can take bytes /
+    strings, iterators of bytes or strings, and files. We can also sub-class / implement
+    a file-like interface for things like multipart-formdata so it's possible to
+    rewind (unlike the current urllib3 interface).
+    Maybe in the future we can expose details about when an object can be sent via
+    'socket.sendfile()', etc. This would have to be communicated somehow to the
+    low-level backend streams.
+
+    When we're handed a file-like object we should take down the starting point
+    in the file via .tell() so we can rewind and put the pointer back after
+    the seek() call in '.content_length()'
+
+    Ref: https://github.com/python-trio/urllib3/issues/135
+    """
+
+    async def content_length(self) -> typing.Optional[int]:
+        """We can get a proper content-length for bytes, strings, file-like objects
+        that are opened in binary mode (is that detectable somehow?). If we hand
+        back 'None' from this property it means that the request should use
+        'Transfer-Encoding: chunked'
+        """
+    async def data_chunks(self) -> typing.AsyncIterable[bytes]:
+        """Factory object for creating an iterable over the wrapped object.
+        If the internal data is not rewindable and this function is called
+        then a 'hip.UnrewindableBodyError' is raised.
+        """

--- a/src/hip/models.pyi
+++ b/src/hip/models.pyi
@@ -26,6 +26,10 @@ class Request:
     Also no reason to store HTTP version here as the final version
     of the request will be determined after the connection has
     been established.
+
+    We allow setting Request.target = '*' for both OPTIONS requests
+    and for HTTP proxies providing the target in absolute form.
+    If unset Request.target defaults to Request.url.path + ('?' + Request.url.params)?
     """
 
     def __init__(self, method: str, url: URLType, *, headers: HeadersType = None,): ...
@@ -37,3 +41,7 @@ class Request:
     def headers(self) -> Headers: ...
     @headers.setter
     def headers(self, value: HeadersType) -> Headers: ...
+    @property
+    def target(self) -> str: ...
+    @target.setter
+    def target(self, value: str) -> None: ...

--- a/src/hip/models.pyi
+++ b/src/hip/models.pyi
@@ -1,0 +1,39 @@
+import typing
+
+URL = typing.Any
+Headers = typing.Any
+
+URLType = typing.Union[str, URL]
+HeadersType = typing.Union[
+    typing.Mapping[str, str],
+    typing.Mapping[bytes, bytes],
+    typing.Iterable[typing.Tuple[str, str]],
+    typing.Iterable[typing.Tuple[bytes, bytes]],
+    Headers,
+]
+
+class Request:
+    """Requests aren't painted async or sync, only their data is.
+    By the time the request has been sent on the network and we'll
+    get a response back the request will be attached to the response
+    via 'SyncResponse.request'. At that point we can remove the 'data'
+    parameter from the Request and only have the metadata left so
+    users can't muck around with a spent Request body.
+    The 'url' type now is just a string but will be a full-featured
+    type in the future. Requests has 'Request.url' as a string but
+    we'll want to expose the whole URL object to do things like
+    'request.url.origin' downstream.
+    Also no reason to store HTTP version here as the final version
+    of the request will be determined after the connection has
+    been established.
+    """
+
+    def __init__(self, method: str, url: URLType, *, headers: HeadersType = None,): ...
+    @property
+    def url(self) -> URL: ...
+    @url.setter
+    def url(self, value: URLType) -> None: ...
+    @property
+    def headers(self) -> Headers: ...
+    @headers.setter
+    def headers(self, value: HeadersType) -> Headers: ...


### PR DESCRIPTION
Opening this branch instead of #151 mostly due to working out of my fork and not using more CI than needed.

I've responded to the comments and moved to a much simpler interface for RequestData that is mostly a Content-Type attached to a byte iterator factory.

Currently Request and RequestData aren't connected in any way, I'm not sure if they need to be if they mostly live within the scope of `Session.request()` anyways. We never present a Request to a user with a body on it.

Also another note here is that our interface now only presents `URL` and `Headers`, even when calling `request.headers = {}` you'll receive a `Headers` object from `x = request.headers`