### PR TITLE
Add URL API

### DIFF
--- a/src/hip/__init__.pyi
+++ b/src/hip/__init__.pyi
@@ -1,1 +1,2 @@
+from .models import URL
 from .status_codes import StatusCode

--- a/src/hip/models.pyi
+++ b/src/hip/models.pyi
@@ -1,0 +1,27 @@
+import typing
+
+Origin = typing.Any
+ParamsValueType = str
+ParamsType = typing.Union[
+    typing.Sequence[typing.Tuple[str, ParamsValueType]],
+    typing.Mapping[str, typing.Optional[ParamsValueType]],
+]
+URLTypes = typing.Union[str, "URL"]
+
+class URL:
+    def __init__(
+        self,
+        url: typing.Optional[URLTypes] = None,
+        *,
+        scheme: typing.Optional[str] = None,
+        username: typing.Optional[str] = None,
+        password: typing.Optional[str] = None,
+        host: typing.Optional[str] = None,
+        port: typing.Optional[int] = None,
+        path: typing.Optional[typing.Union[str, typing.Sequence[str]]] = None,
+        params: typing.Optional[ParamsType] = None,
+        fragment: typing.Optional[str] = None,
+    ): ...
+    @property
+    def origin(self) -> Origin: ...
+    def join(self, url: URLTypes) -> "URL": ...


### PR DESCRIPTION
Fairly simple API surface for URL. Mostly there for easier querying by users and to ensure users aren't using an improper parsing method.