### PR TITLE
Fix GitHub Actions coverage for pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         nox -s test-${{ matrix.python-version }}
     - name: Coverage upload
       env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        CODECOV_TOKEN: 3bb38a90-137e-4efe-9627-ca66de472c13
       run: |
         python.exe -m pip install codecov
         python.exe -m codecov -f coverage.xml


### PR DESCRIPTION
Using the plan from @njsmith in #184:

> I guess we can just stick the codecov token in here in plaintext for now – I think the only danger is that someone could... maliciously upload false coverage reports? Seems like a pretty low risk to me. And then if Github/Codecov get their acts together and fix this, we can always revoke that token.