### PR TITLE
Document Hip in the README, not urllib3

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,39 +1,32 @@
-urllib3
-=======
+hip
+===
 
-.. image:: https://travis-ci.org/urllib3/urllib3.svg?branch=master
+.. image:: https://travis-ci.org/python-trio/hip.svg?branch=master
         :alt: Build status on Travis
-        :target: https://travis-ci.org/urllib3/urllib3
+        :target: https://travis-ci.org/python-trio/hip
 
-.. image:: https://img.shields.io/appveyor/ci/urllib3/urllib3/master.svg
-        :alt: Build status on AppVeyor
-        :target: https://ci.appveyor.com/project/urllib3/urllib3
+.. image:: https://github.com/python-trio/hip/workflows/CI/badge.svg
+        :alt: Build status on GitHub Actions
+        :target: https://github.com/python-trio/hip/actions
 
-.. image:: https://readthedocs.org/projects/urllib3/badge/?version=latest
-        :alt: Documentation Status
-        :target: https://urllib3.readthedocs.io/en/latest/
-
-.. image:: https://img.shields.io/codecov/c/github/urllib3/urllib3.svg
+.. image:: https://img.shields.io/codecov/c/github/python-trio/hip.svg
         :alt: Coverage Status
-        :target: https://codecov.io/gh/urllib3/urllib3
+        :target: https://codecov.io/gh/python-trio/hip
 
-.. image:: https://img.shields.io/pypi/v/urllib3.svg?maxAge=86400
+.. image:: https://img.shields.io/pypi/v/hip.svg?maxAge=86400
         :alt: PyPI version
-        :target: https://pypi.org/project/urllib3/
+        :target: https://pypi.org/project/hip/
 
-.. image:: https://badges.gitter.im/python-urllib3/Lobby.svg
+.. image:: https://badges.gitter.im/python-trio/hip.svg
         :alt: Gitter
-        :target: https://gitter.im/python-urllib3/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge
+        :target: https://gitter.im/python-trio/hip
 
 .. image:: https://img.shields.io/badge/code%20style-black-000000.svg
     :target: https://github.com/psf/black
 
-urllib3 is a powerful, *sanity-friendly* HTTP client for Python. Much of the
-Python ecosystem already uses urllib3 and you should too.
-urllib3 brings many critical features that are missing from the Python
-standard libraries:
+hip is a new Python HTTP client for everybody. It supports synchronous Python (just like requests does), but also Trio, asyncio and Curio.
 
-*Currently not supporting SOCKS proxies, pyOpenSSL and SecureTransport.*
+hip is robust as it is based on urllib3 and uses its extensive test suite that was refined over the years. I also shares most urllib3 features:
 
 - Thread safety.
 - Connection pooling.
@@ -41,70 +34,59 @@ standard libraries:
 - File uploads with multipart encoding.
 - Helpers for retrying requests and dealing with HTTP redirects.
 - Support for gzip, deflate, and brotli encoding.
-- Proxy support for HTTP and SOCKS.
+- Proxy support for HTTP.
 - 100% test coverage.
 
-urllib3 is powerful and easy to use::
+However, we currently do not support SOCKS proxies nor the pyOpenSSL and SecureTransport TLS backends.
 
-    >>> import urllib3
-    >>> http = urllib3.PoolManager()
+Sample code
+-----------
+
+hip is powerful and easy to use::
+
+    >>> import hip
+    >>> http = hip.PoolManager()
     >>> r = http.request('GET', 'http://httpbin.org/robots.txt')
     >>> r.status
     200
     >>> r.data
     'User-agent: *\nDisallow: /deny\n'
 
+It also supports async/await::
+
+    import hip
+    import trio
+
+    async def main():
+        with hip.AsyncPoolManager() as http:
+            r = await http.request("GET", "http://httpbin.org/uuid")
+            print("Status:", r.status)  # 200
+            print("Data:", await r.read()). # 'User-agent: *\nDisallow: /deny\n'
+
+    trio.run(main)
 
 Installing
 ----------
 
-urllib3 can be installed with `pip <https://pip.pypa.io>`_::
+hip can be installed with `pip <https://pip.pypa.io>`_::
 
-    $ pip install urllib3
+    $ pip install hip
 
-Alternatively, you can grab the latest source code from `GitHub <https://github.com/urllib3/urllib3>`_::
+Alternatively, you can grab the latest source code from `GitHub <https://github.com/python-trio/hip>`_::
 
-    $ git clone git://github.com/urllib3/urllib3.git
+    $ git clone git://github.com/python-trio/hip.git
     $ python setup.py install
 
 
 Documentation
 -------------
 
-urllib3 has usage and reference documentation at `urllib3.readthedocs.io <https://urllib3.readthedocs.io>`_.
+hip will soon have usage and reference documentation at `hip.readthedocs.io <https://hip.readthedocs.io/en/latest/>`_.
 
 
 Contributing
 ------------
 
-urllib3 happily accepts contributions. Please see our
-`contributing documentation <https://urllib3.readthedocs.io/en/latest/contributing.html>`_
+hip happily accepts contributions. Please see our
+`contributing documentation <https://hip.readthedocs.io/en/latest/contributing.html>`_
 for some tips on getting started.
-
-
-Maintainers
------------
-
-- `@sethmlarson <https://github.com/sethmlarson>`_ (Seth M. Larson)
-- `@pquentin <https://github.com/pquentin>`_ (Quentin Pradet)
-- `@theacodes <https://github.com/theacodes>`_ (Thea Flowers)
-- `@haikuginger <https://github.com/haikuginger>`_ (Jess Shapiro)
-- `@lukasa <https://github.com/lukasa>`_ (Cory Benfield)
-- `@sigmavirus24 <https://github.com/sigmavirus24>`_ (Ian Cordasco)
-- `@shazow <https://github.com/shazow>`_ (Andrey Petrov)
-
-👋
-
-
-Sponsorship
------------
-
-If your company benefits from this library, please consider `sponsoring its
-development <https://urllib3.readthedocs.io/en/latest/contributing.html#sponsorship-project-grants>`_.
-
-Sponsors include:
-
-- Abbott (2018-2019), sponsored `@sethmlarson <https://github.com/sethmlarson>`_'s work on urllib3.
-- Google Cloud Platform (2018-2019), sponsored `@theacodes <https://github.com/theacodes>`_'s work on urllib3.
-- Akamai (2017-2018), sponsored `@haikuginger <https://github.com/haikuginger>`_'s work on urllib3
-- Hewlett Packard Enterprise (2016-2017), sponsored `@Lukasa’s <https://github.com/Lukasa>`_ work on urllib3.

--- a/README.rst
+++ b/README.rst
@@ -26,6 +26,8 @@ Hip
 
 Hip is a new Python HTTP client for everybody. It supports synchronous Python (just like requests does), but also Trio, asyncio and Curio.
 
+.. important:: Hip is still in its early days, use at your own risk! In particular, the async support is still experimental and untested.
+
 Hip is robust as it is based on urllib3 and uses its extensive test suite that was refined over the years. It also shares most urllib3 features:
 
 - Thread safety.

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-hip
+Hip
 ===
 
 .. image:: https://travis-ci.org/python-trio/hip.svg?branch=master
@@ -24,9 +24,9 @@ hip
 .. image:: https://img.shields.io/badge/code%20style-black-000000.svg
     :target: https://github.com/psf/black
 
-hip is a new Python HTTP client for everybody. It supports synchronous Python (just like requests does), but also Trio, asyncio and Curio.
+Hip is a new Python HTTP client for everybody. It supports synchronous Python (just like requests does), but also Trio, asyncio and Curio.
 
-hip is robust as it is based on urllib3 and uses its extensive test suite that was refined over the years. It also shares most urllib3 features:
+Hip is robust as it is based on urllib3 and uses its extensive test suite that was refined over the years. It also shares most urllib3 features:
 
 - Thread safety.
 - Connection pooling.
@@ -42,7 +42,7 @@ However, we currently do not support SOCKS proxies nor the pyOpenSSL and SecureT
 Sample code
 -----------
 
-hip is powerful and easy to use::
+Hip is powerful and easy to use::
 
     >>> import hip
     >>> http = hip.PoolManager()
@@ -68,7 +68,7 @@ It also supports async/await::
 Installing
 ----------
 
-hip can be installed with `pip <https://pip.pypa.io>`_::
+Hip can be installed with `pip <https://pip.pypa.io>`_::
 
     $ pip install hip
 
@@ -81,12 +81,12 @@ Alternatively, you can grab the latest source code from `GitHub <https://github.
 Documentation
 -------------
 
-hip will soon have usage and reference documentation at `hip.readthedocs.io <https://hip.readthedocs.io/en/latest/>`_.
+Hip will soon have usage and reference documentation at `hip.readthedocs.io <https://hip.readthedocs.io/en/latest/>`_.
 
 
 Contributing
 ------------
 
-hip happily accepts contributions. Please see our
+Hip happily accepts contributions. Please see our
 `contributing documentation <https://hip.readthedocs.io/en/latest/contributing.html>`_
 for some tips on getting started.

--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ Hip
         :alt: Build status on GitHub Actions
         :target: https://github.com/python-trio/hip/actions
 
-.. image:: https://img.shields.io/codecov/c/github/python-trio/hip.svg
+.. image:: https://codecov.io/gh/python-trio/hip/branch/master/graph/badge.svg
         :alt: Coverage Status
         :target: https://codecov.io/gh/python-trio/hip
 

--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ hip
 
 hip is a new Python HTTP client for everybody. It supports synchronous Python (just like requests does), but also Trio, asyncio and Curio.
 
-hip is robust as it is based on urllib3 and uses its extensive test suite that was refined over the years. I also shares most urllib3 features:
+hip is robust as it is based on urllib3 and uses its extensive test suite that was refined over the years. It also shares most urllib3 features:
 
 - Thread safety.
 - Connection pooling.


### PR DESCRIPTION
This is a first draft as requested by @njsmith in https://gitter.im/python-trio/hip?at=5e268f6269a7b51d4d54ecae.

You can look at the output here: https://github.com/pquentin/hip/tree/hip-readme