### PR TITLE
Fix compatibility with unasync 0.5.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,4 +12,4 @@ base_path = os.path.dirname(__file__)
 with open(os.path.join(base_path, "src", "hip", "__init__.py")) as fp:
     version = re.match(r".*__version__ = \"(.*?)\"", fp.read(), re.S).group(1)
 
-setup(version=version, cmdclass={"build_py": unasync.build_py})
+setup(version=version, cmdclass={"build_py": unasync.cmdclass_build_py()})


### PR DESCRIPTION
To work around the GitHub bug from #205. The previous workaround did not work since GitHub noticed that the branch contained the same commits.