### PR TITLE
Add AsyncBackend ABC, normalize backend interfaces

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -78,6 +78,7 @@ omit =
     *hip/_backends/anyio_backend.py
     *hip/_backends/trio_backend.py
     *hip/_backends/twisted_backend.py
+    *hip/_backends/async_backend.py
     *hip/contrib/socks.py
 
 [coverage:report]

--- a/src/hip/_backends/async_backend.py
+++ b/src/hip/_backends/async_backend.py
@@ -1,0 +1,53 @@
+from abc import abstractmethod, ABC
+from ssl import SSLContext
+from typing import Optional, Tuple, Iterable, Union, Any, Dict, Callable, Awaitable
+
+
+class AsyncBackend(ABC):
+    @abstractmethod
+    async def connect(
+        self,
+        host: str,
+        port: int,
+        connect_timeout: Optional[float],
+        source_address: Optional[Tuple[str, int]] = None,
+        socket_options: Optional[Iterable[Tuple[int, int, int]]] = None,
+    ) -> "AsyncSocket":
+        raise NotImplementedError()
+
+
+class AsyncSocket(ABC):
+    @abstractmethod
+    async def start_tls(
+        self, server_hostname: Optional[str], ssl_context: SSLContext
+    ) -> "AsyncSocket":
+        raise NotImplementedError()
+
+    @abstractmethod
+    def getpeercert(self, binary_form: bool = False) -> Union[bytes, Dict[str, Any]]:
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def receive_some(self, read_timeout: Optional[float]) -> bytes:
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def send_and_receive_for_a_while(
+        self,
+        produce_bytes: Callable[[], Awaitable[bytes]],
+        consume_bytes: Callable[[bytes], None],
+        read_timeout: Optional[float],
+    ) -> None:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def forceful_close(self):
+        raise NotImplementedError()
+
+    @abstractmethod
+    def is_readable(self) -> bool:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def set_readable_watch_state(self, enabled: bool) -> None:
+        raise NotImplementedError()


### PR DESCRIPTION
- Added `AsyncBackend` and `AsyncSocket` ABCs so we can maintain the same interface across all implementations. Will also be useful in the future for type hinting.
- Added `read_timeout` to `AsyncSocket.receive_some()` that currently does nothing so that `_read_until_event` is happy with all async socket interfaces.
- Use `suppress_ragged_eofs=True` and `server_hostname` parameters in `anyio.SocketStream.start_tls()`
- Potential fix for Trio TLS by calling `SSLStream.do_handshake()` within `TrioSocket.start_tls()` so that `getpeercert()` is available before sending data. Can revert this if we have a better idea in mind?

All of these changes combine so that the `async-demo.py` works with HTTPS! :)