### PR TITLE
Use Trio RTD theme, add readthedocs.yml

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,13 @@
+version: 2
+
+sphinx:
+  configuration: docs/conf.py
+
+formats: all
+
+python:
+  version: 3.7
+  install:
+    - requirements: docs/requirements.txt
+    - method: pip
+      path: .

--- a/docs/_static/hackrtd.css
+++ b/docs/_static/hackrtd.css
@@ -1,0 +1,112 @@
+/* Temporary hack to work around bug in rtd theme 2.0 through 2.4
+   See https://github.com/rtfd/sphinx_rtd_theme/pull/382
+*/
+pre {
+    line-height: normal !important;
+}
+
+/* Make .. deprecation:: blocks visible
+ * (by default they're entirely unstyled)
+ */
+.deprecated {
+    background-color: #ffe13b;
+}
+
+/* Add a snakey triskelion ornament to <hr>
+ * https://stackoverflow.com/questions/8862344/css-hr-with-ornament/18541258#18541258
+ * but only do it to <hr>s in the content box, b/c the RTD popup control panel
+ * thingummy also has an <hr> in it, and putting the ornament on that looks
+ * *really weird*. (In particular, the background color is wrong.)
+ */
+.rst-content hr:after {
+    /* This .svg gets displayed on top of the middle of the hrule. It has a box
+     * behind the logo that's colored to match the RTD theme body background
+     * color (#fcfcfc), which hides the middle part of the hrule to make it
+     * look like there's a gap in it. The size of the box determines the size
+     * of the gap.
+     */
+    background: url('ornament.svg') no-repeat top center;
+    background-size: contain;
+    content: "";
+    display: block;
+    height: 30px;
+    position: relative;
+    top: -15px;
+}
+
+/* Hacks to make the upper-left logo area look nicer */
+
+.wy-side-nav-search {
+    /* Lighter background color to match logo */
+    background-color: #d2e7fa !important;
+}
+
+.wy-side-nav-search > a {
+    color: #306998 !important;
+}
+
+.wy-side-nav-search > a.logo {
+    display: block !important;
+    padding-bottom: 0.809em !important;
+}
+
+.wy-side-nav-search > a img.logo {
+    display: inline !important;
+    padding: 0 !important;
+}
+
+.trio-version {
+    display: inline;
+    /* I *cannot* figure out how to get the version text vertically centered
+       on the logo. Oh well...
+    height: 32px;
+    line-height: 32px;
+    */
+}
+
+.wy-side-nav-search > a {
+    /* Mostly this is just to simplify things, so we don't have margin/padding
+     * on both the <a> and the <img> inside it */
+    margin: 0 !important;
+    padding: 0 !important;
+}
+
+/* Get rid of the weird super dark "Contents" label that wastes vertical space
+ */
+.wy-menu-vertical > p.caption {
+    display: none !important;
+}
+
+/* I do not like RTD's use of Roboto Slab for headlines. So force it back to
+ * Lato (or whatever fallback it's using if Lato isn't available for some
+ * reason). I also experimented with using Montserrat to be extra obnoxiously
+ * on brand, but honestly you couldn't really tell so there wasn't much point
+ * in adding page weight for that, and this is going to match the body text
+ * better. (Montserrat for body text *definitely* didn't look good, alas.)
+ */
+h1, h2, h3, h4, h5, h6, legend, .rst-content .toctree-wrapper p.caption {
+    font-family: inherit !important;
+}
+
+/* Get rid of the horrible red for literal content */
+.rst-content tt.literal, .rst-content tt.literal, .rst-content code.literal {
+    color: #222 !important;
+}
+
+/* Style the "Need help?" text just underneath the search box */
+.trio-help-hint {
+    line-height: normal;
+    margin-bottom: 0;
+    /* font-size: 12px; */
+    font-size: 80%;  /* matches the "Search docs" box */
+    padding-top: 6px;
+    color: #306998;
+    text-align: center;
+}
+
+a.trio-help-hint, .trio-help-hint a:link, .trio-help-hint a:visited {
+    color: inherit;
+    /* Like text-decoration: underline, but with a thinner line */
+    text-decoration: none;
+    border-bottom: 1px solid;
+}

--- a/docs/_templates/fonts.html
+++ b/docs/_templates/fonts.html
@@ -1,1 +1,0 @@
-<link href='https://fonts.googleapis.com/css?family=Roboto|Roboto+Mono' rel='stylesheet' type='text/css'>

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,0 +1,24 @@
+{#
+https://stackoverflow.com/questions/25243482/how-to-add-sphinx-generated-index-to-the-sidebar-when-using-read-the-docs-theme
+#}
+{% extends "!layout.html" %}
+
+{% block sidebartitle %}
+<a class="logo" href="{{ pathto(master_doc) }}">
+  <!-- TODO: <img class="logo" src="{{ pathto('_static/' + logo, 1) }}" /> -->
+  {%- set nav_version = version %}
+  {% if READTHEDOCS and current_version %}
+    {%- set nav_version = current_version %}
+  {% endif %}
+  {# don't show the version on RTD if it's the default #}
+  {% if nav_version != 'latest' %}
+    <div class="trio-version">{{ nav_version }}</div>
+  {% endif %}
+</a>
+
+{% include "searchbox.html" %}
+
+<p class="trio-help-hint">Need help? <a
+href="https://gitter.im/python-trio/hip">Live chat</a>, <a
+href="https://stackoverflow.com/questions/ask?tags=python+python-hip">StackOverflow</a>.</p>
+{% endblock %}

--- a/docs/advanced-usage.rst
+++ b/docs/advanced-usage.rst
@@ -127,7 +127,7 @@ SOCKS5 proxies. In order to use SOCKS proxies you will need to install
 `PySocks <https://pypi.org/project/PySocks/>`_ or install hip with the
 ``socks`` extra::
 
-    pip install hip[socks]
+    python -m pip install hip[socks]
 
 Once PySocks is installed, you can use
 :class:`~contrib.socks.SOCKSProxyManager`::

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,38 +1,57 @@
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-from datetime import date
+
 import os
 import sys
+import datetime
 
-import alabaster
-
-# If extensions (or modules to document with autodoc) are in another directory,
-# add these directories to sys.path here. If the directory is relative to the
-# documentation root, use os.path.abspath to make it absolute, like shown here.
-
-root_path = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-sys.path.insert(0, root_path)
+sys.path.insert(0, os.path.abspath("../.."))
 
 import hip
 
+# Warn about all references to unknown targets
+nitpicky = False  # TODO: Switch this to 'True' after interface has solidified.
+nitpick_ignore = []
+autodoc_inherit_docstrings = False
+default_role = "obj"
 
-# -- General configuration -----------------------------------------------------
+# XX hack the RTD theme until
+#   https://github.com/rtfd/sphinx_rtd_theme/pull/382
+# is shipped (should be in the release after 0.2.4)
+# ...note that this has since grown to contain a bunch of other CSS hacks too
+# though.
 
-# Add any Sphinx extension module names here, as strings. They can be extensions
-# coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
+
+def setup(app):
+    app.add_css_file("hackrtd.css")
+
+
+# -- General configuration ------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
 extensions = [
-    "alabaster",
     "sphinx.ext.autodoc",
-    "sphinx.ext.doctest",
     "sphinx.ext.intersphinx",
+    "sphinx.ext.coverage",
+    "sphinx.ext.napoleon",
+    "sphinxcontrib_trio",
 ]
 
-# Test code blocks only when explicitly specified
-doctest_test_doctest_blocks = ""
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3", None),
+}
+
+autodoc_member_order = "bysource"
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
 
-# The suffix of source filenames.
+# The suffix(es) of source filenames.
+# You can specify multiple suffix as a list of string:
+#
+# source_suffix = ['.rst', '.md']
 source_suffix = ".rst"
 
 # The master toctree document.
@@ -40,53 +59,103 @@ master_doc = "index"
 
 # General information about the project.
 project = "Hip"
-release = version = hip.__version__
 author = hip.__author__
-copyright = "{year}, {author}".format(year=date.today().year, author=author)
+copyright = "%d, %s" % (datetime.date.today().year, author)
+version = hip.__version__
+release = version
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ["_build"]
+# This patterns also effect to html_static_path and html_extra_path
+exclude_patterns = []
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = "sphinx"
+pygments_style = "default"
 
-# -- Options for HTML output ---------------------------------------------------
+# If true, `todo` and `todoList` produce output, else they produce nothing.
+todo_include_todos = False
 
-# The theme to use for HTML and HTML Help pages.  See the documentation for
-# a list of builtin themes.
-html_theme = "alabaster"
+# -- Options for HTML output ----------------------------------------------
+
+# We have to set this ourselves, not only because it's useful for local
+# testing, but also because if we don't then RTD will throw away our
+# html_theme_options.
+import sphinx_rtd_theme
+
+html_theme = "sphinx_rtd_theme"
+html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
 html_theme_options = {
-    "description": "Hip is a new Python HTTP client for everybody",
-    "github_user": "python-trio",
-    "github_repo": "hip",
-    "github_button": False,
-    "github_banner": True,
-    "travis_button": True,
-    "show_powered_by": False,
-    "font_family": "'Roboto', Georgia, sans",
-    "head_font_family": "'Roboto', Georgia, serif",
-    "code_font_family": "'Roboto Mono', 'Consolas', monospace",
+    # default is 2
+    # show deeper nesting in the RTD theme's sidebar TOC
+    # https://stackoverflow.com/questions/27669376/
+    # I'm not 100% sure this actually does anything with our current
+    # versions/settings...
+    "navigation_depth": 4,
+    "logo_only": True,
+    "prev_next_buttons_location": "both",
 }
 
-# Add any paths that contain custom themes here, relative to this directory.
-html_theme_path = [alabaster.get_path()]
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ["_static"]
 
-# Custom sidebar templates, maps document names to template names.
-html_sidebars = {
-    "**": [
-        "about.html",
-        "navigation.html",
-        "relations.html",
-        "searchbox.html",
-        "donate.html",
-    ]
+
+# -- Options for HTMLHelp output ------------------------------------------
+
+# Output file base name for HTML help builder.
+htmlhelp_basename = "Hipdoc"
+
+
+# -- Options for LaTeX output ---------------------------------------------
+
+latex_elements = {
+    # The paper size ('letterpaper' or 'a4paper').
+    #
+    # 'papersize': 'letterpaper',
+    # The font size ('10pt', '11pt' or '12pt').
+    #
+    # 'pointsize': '10pt',
+    # Additional stuff for the LaTeX preamble.
+    #
+    # 'preamble': '',
+    # Latex figure (float) alignment
+    #
+    # 'figure_align': 'htbp',
 }
 
-intersphinx_mapping = {
-    "python": ("https://docs.python.org/3.8", None),
-}
+# Grouping the document tree into LaTeX files. List of tuples
+# (source start file, target name, title,
+#  author, documentclass [howto, manual, or own class]).
+latex_documents = [
+    (master_doc, "Hip.tex", "Hip Documentation", author, "manual"),
+]
+
+
+# -- Options for manual page output ---------------------------------------
+
+# One entry per manual page. List of tuples
+# (source start file, name, description, authors, manual section).
+man_pages = [(master_doc, "hip", "Hip Documentation", [author], 1)]
+
+
+# -- Options for Texinfo output -------------------------------------------
+
+# Grouping the document tree into Texinfo files. List of tuples
+# (source start file, target name, title, author,
+#  dir menu entry, description, category)
+texinfo_documents = [
+    (
+        master_doc,
+        "Hip",
+        "Hip Documentation",
+        author,
+        "Hip",
+        "One line description of project.",
+        "Miscellaneous",
+    ),
+]

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -24,7 +24,7 @@ Setting up your development environment
 In order to setup the development environment all that you need is 
 `nox <https://nox.thea.codes/en/stable/index.html>`_ installed in your machine::
 
-  $ pip install --user --upgrade nox
+  $ python -m pip install --user --upgrade nox
 
 
 Running the tests

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,5 +1,5 @@
-Hip
-===
+Hip: A new Python HTTP client for Everyone
+==========================================
 
 .. toctree::
    :hidden:

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,5 @@
 -r ../dev-requirements.txt
-sphinx
-alabaster
+sphinx>=1.7.0
+sphinx-rtd-theme
+sphinxcontrib-trio
 requests>=2,<2.16


### PR DESCRIPTION
RTD is failing because it installs the project via `python setup.py install` before installing `dev-requirements.txt` so doesn't have `unasync`. Added a `readthedocs.yml` file so we can control the install order and have RTD use `pip install .` instead of `python setup.py install`

I also pulled most of Trio's template, it looks good for now and the docs now just need content to be improved to look really nice. No logo yet so that section is empty and didn't immediately link to the Trio Discourse. The Stackoverflow tag doesn't exist yet but doesn't hurt to link to nothing?