### PR TITLE
Add Gitter chat button to docs

### DIFF
--- a/docs/_static/gitter-sidecar.js
+++ b/docs/_static/gitter-sidecar.js
@@ -1,0 +1,3 @@
+((window.gitter = {}).chat = {}).options = {
+    room: 'python-trio/hip'
+};

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,6 +24,8 @@ default_role = "obj"
 
 def setup(app):
     app.add_css_file("hackrtd.css")
+    app.add_js_file("gitter-sidecar.js")
+    app.add_js_file("https://sidecar.gitter.im/dist/sidecar.v1.js")
 
 
 # -- General configuration ------------------------------------------------


### PR DESCRIPTION
Makes it easy for users that have questions / want to discuss Hip to find our Gitter room.
This approach was taken from https://github.com/tiangolo/fastapi/pull/1061