### PR TITLE
Add support for async files as request body

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,17 @@ with open(os.path.join(base_path, "src", "ahip", "__init__.py")) as fp:
 setup(
     version=version,
     cmdclass={
-        "build_py": unasync.cmdclass_build_py(rules=[unasync.Rule("/ahip/", "/hip/")])
+        "build_py": unasync.cmdclass_build_py(
+            rules=[
+                unasync.Rule(
+                    "/ahip/",
+                    "/hip/",
+                    additional_replacements={
+                        "anext": "next",
+                        "await_if_coro": "return_non_coro",
+                    },
+                )
+            ]
+        )
     },
 )

--- a/src/ahip/_backends/anyio_backend.py
+++ b/src/ahip/_backends/anyio_backend.py
@@ -44,7 +44,7 @@ class AnyIOSocket(AsyncSocket):
     def getpeercert(self, binary_form=False):
         return self._stream.getpeercert(binary_form=binary_form)
 
-    async def receive_some(self):
+    async def receive_some(self, read_timeout):
         return await self._stream.receive_some(BUFSIZE)
 
     async def send_and_receive_for_a_while(

--- a/src/ahip/connectionpool.py
+++ b/src/ahip/connectionpool.py
@@ -620,7 +620,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
 
         # Rewind body position, if needed. Record current position
         # for future rewinds in the event of a redirect/retry.
-        body_pos = set_file_position(body, body_pos)
+        body_pos = await set_file_position(body, body_pos)
 
         if body is not None:
             _add_transport_headers(headers)

--- a/src/ahip/poolmanager.py
+++ b/src/ahip/poolmanager.py
@@ -323,7 +323,7 @@ class PoolManager(RequestMethods):
         # for future rewinds in the event of a redirect/retry.
         body = kw.get("body")
         body_pos = kw.get("body_pos")
-        kw["body_pos"] = set_file_position(body, body_pos)
+        kw["body_pos"] = await set_file_position(body, body_pos)
 
         if "headers" not in kw:
             kw["headers"] = self.headers.copy()

--- a/src/ahip/util/unasync.py
+++ b/src/ahip/util/unasync.py
@@ -1,0 +1,40 @@
+"""Set of utility functions for unasync that transform into sync counterparts cleanly"""
+
+import inspect
+
+_original_next = next
+
+
+def is_async_mode():
+    """Tests if we're in the async part of the code or not"""
+
+    async def f():
+        """Unasync transforms async functions in sync functions"""
+        return None
+
+    obj = f()
+    if obj is None:
+        return False
+    else:
+        obj.close()  # prevent unawaited coroutine warning
+        return True
+
+
+ASYNC_MODE = is_async_mode()
+
+
+async def anext(x):
+    return await x.__anext__()
+
+
+async def await_if_coro(x):
+    if inspect.iscoroutine(x):
+        return await x
+    return x
+
+
+next = _original_next
+
+
+def return_non_coro(x):
+    return x

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -14,7 +14,7 @@ from dummyserver.server import (
 
 # We support Python 3.6+ for async code
 if sys.version_info[:2] < (3, 6):
-    collect_ignore_glob = ["async/*.py", "with_dummyserver/async/*.py"]
+    collect_ignore_glob = ["async/*.py", "with_dummyserver/async*/*.py"]
 
 # The Python 3.8+ default loop on Windows breaks Tornado
 @pytest.fixture(scope="session", autouse=True)

--- a/test/with_dummyserver/async/test_poolmanager.py
+++ b/test/with_dummyserver/async/test_poolmanager.py
@@ -1,4 +1,7 @@
-from ahip import PoolManager
+import io
+import pytest
+from ahip import PoolManager, Retry
+from ahip.exceptions import UnrewindableBodyError
 
 from test.with_dummyserver import conftest
 
@@ -22,3 +25,97 @@ class TestPoolManager:
 
             assert r.status == 200
             assert r.data == b"Dummy server!"
+
+
+class TestFileUploads:
+    @conftest.test_all_backends
+    async def test_redirect_put_file(self, http_server, backend, anyio_backend):
+        """PUT with file object should work with a redirection response"""
+        base_url = "http://{}:{}".format(http_server.host, http_server.port)
+        retry = Retry(total=3, status_forcelist=[418])
+        # httplib reads in 8k chunks; use a larger content length
+        content_length = 65535
+        data = b"A" * content_length
+        uploaded_file = io.BytesIO(data)
+        headers = {
+            "test-name": "test_redirect_put_file",
+            "Content-Length": str(content_length),
+        }
+        url = "%s/redirect?target=/echo&status=307" % base_url
+
+        with PoolManager(backend=backend) as http:
+            resp = await http.urlopen(
+                "PUT", url, headers=headers, retries=retry, body=uploaded_file
+            )
+            assert resp.status == 200
+            assert resp.data == data
+
+    @conftest.test_all_backends
+    async def test_retries_put_filehandle(self, http_server, backend, anyio_backend):
+        """HTTP PUT retry with a file-like object should not timeout"""
+        base_url = "http://{}:{}".format(http_server.host, http_server.port)
+        retry = Retry(total=3, status_forcelist=[418])
+        # httplib reads in 8k chunks; use a larger content length
+        content_length = 65535
+        data = b"A" * content_length
+        uploaded_file = io.BytesIO(data)
+        headers = {
+            "test-name": "test_retries_put_filehandle",
+            "Content-Length": str(content_length),
+        }
+
+        with PoolManager(backend=backend) as http:
+            resp = await http.urlopen(
+                "PUT",
+                "%s/successful_retry" % base_url,
+                headers=headers,
+                retries=retry,
+                body=uploaded_file,
+                redirect=False,
+            )
+            assert resp.status == 200
+
+    @conftest.test_all_backends
+    async def test_redirect_with_failed_tell(self, http_server, backend, anyio_backend):
+        """Abort request if failed to get a position from tell()"""
+
+        base_url = "http://{}:{}".format(http_server.host, http_server.port)
+
+        class BadTellObject(io.BytesIO):
+            def tell(self):
+                raise IOError
+
+        body = BadTellObject(b"the data")
+        url = "%s/redirect?target=/successful_retry" % base_url
+        # httplib uses fileno if Content-Length isn't supplied,
+        # which is unsupported by BytesIO.
+        headers = {"Content-Length": "8"}
+
+        with PoolManager() as http:
+            with pytest.raises(UnrewindableBodyError) as e:
+                await http.urlopen("PUT", url, headers=headers, body=body)
+            assert "Unable to record file position for" in str(e.value)
+
+    @conftest.test_all_backends
+    async def test_redirect_with_failed_seek(self, http_server, backend, anyio_backend):
+        """Abort request if failed to restore position with seek()"""
+
+        base_url = "http://{}:{}".format(http_server.host, http_server.port)
+
+        class BadSeekObject(io.BytesIO):
+            def seek(self, *_):
+                raise IOError
+
+        body = BadSeekObject(b"the data")
+        url = "%s/redirect?target=/successful_retry" % base_url
+        # httplib uses fileno if Content-Length isn't supplied,
+        # which is unsupported by BytesIO.
+        headers = {"Content-Length": "8"}
+
+        with PoolManager() as http:
+            with pytest.raises(UnrewindableBodyError) as e:
+                await http.urlopen("PUT", url, headers=headers, body=body)
+            assert (
+                "An error occurred when rewinding request body for redirect/retry."
+                == str(e.value)
+            )

--- a/test/with_dummyserver/async_only/test_poolmanager.py
+++ b/test/with_dummyserver/async_only/test_poolmanager.py
@@ -1,0 +1,100 @@
+import io
+import pytest
+import trio
+import anyio
+from ahip import PoolManager
+from ahip.exceptions import UnrewindableBodyError
+
+from test.with_dummyserver import conftest
+
+
+class TestFileUploads:
+    @conftest.test_all_backends
+    async def test_upload_anyio_async_files(self, http_server, backend, anyio_backend):
+        """Uploading a file opened via 'anyio.aopen()' should be possible"""
+        base_url = "http://{}:{}".format(http_server.host, http_server.port)
+
+        with open(__file__, mode="rb") as f:
+            data = f.read()
+            content_length = len(data)
+
+        headers = {
+            "Content-Length": str(content_length),
+        }
+        url = "%s/echo" % base_url
+
+        with PoolManager(backend=backend) as http:
+            async with await anyio.aopen(__file__, mode="rb") as f:
+                resp = await http.urlopen("PUT", url, headers=headers, body=f)
+                assert resp.status == 200
+                assert resp.data == data
+
+    @pytest.mark.trio
+    async def test_upload_trio_wrapped_files(self, http_server):
+        """Uploading a file wrapped via 'trio.wrap_file()' should be possible"""
+        base_url = "http://{}:{}".format(http_server.host, http_server.port)
+
+        with open(__file__, mode="rb") as f:
+            data = f.read()
+            content_length = len(data)
+
+        headers = {
+            "Content-Length": str(content_length),
+        }
+        url = "%s/echo" % base_url
+
+        with PoolManager(backend="trio") as http:
+            with open(__file__, mode="rb") as f:
+                f = trio.wrap_file(f)
+                resp = await http.urlopen("PUT", url, headers=headers, body=f)
+                assert resp.status == 200
+                assert resp.data == data
+
+    @conftest.test_all_backends
+    async def test_redirect_with_failed_async_tell(
+        self, http_server, backend, anyio_backend
+    ):
+        """Abort request if failed to get a position from async tell()"""
+
+        base_url = "http://{}:{}".format(http_server.host, http_server.port)
+
+        class BadTellObject(io.BytesIO):
+            async def tell(self):
+                raise IOError
+
+        body = BadTellObject(b"the data")
+        url = "%s/redirect?target=/successful_retry" % base_url
+        # httplib uses fileno if Content-Length isn't supplied,
+        # which is unsupported by BytesIO.
+        headers = {"Content-Length": "8"}
+
+        with PoolManager() as http:
+            with pytest.raises(UnrewindableBodyError) as e:
+                await http.urlopen("PUT", url, headers=headers, body=body)
+            assert "Unable to record file position for" in str(e.value)
+
+    @conftest.test_all_backends
+    async def test_redirect_with_failed_async_seek(
+        self, http_server, backend, anyio_backend
+    ):
+        """Abort request if failed to restore position with async seek()"""
+
+        base_url = "http://{}:{}".format(http_server.host, http_server.port)
+
+        class BadSeekObject(io.BytesIO):
+            async def seek(self, *_):
+                raise IOError
+
+        body = BadSeekObject(b"the data")
+        url = "%s/redirect?target=/successful_retry" % base_url
+        # httplib uses fileno if Content-Length isn't supplied,
+        # which is unsupported by BytesIO.
+        headers = {"Content-Length": "8"}
+
+        with PoolManager() as http:
+            with pytest.raises(UnrewindableBodyError) as e:
+                await http.urlopen("PUT", url, headers=headers, body=body)
+            assert (
+                "An error occurred when rewinding request body for redirect/retry."
+                == str(e.value)
+            )


### PR DESCRIPTION
This PR adds support async files like `trio.wrap_file(open())` and `anyio.aopen()` and does some refactoring that will allow us to accept other async iterables as data sources easily.

- Made `set_file_position()` and `rewind_body()` able to handle async files
- Added an `unasync.py` file to `hip.util` for small unasync-related utilities like `anext()` and `await_if_coro()`. See https://github.com/python-trio/unasync/issues/65 for more info here too.
- Added `read_timeout` to `AnyIOSocket.receive_some()`, don't know how that bug wasn't caught earlier.
- Turned a lot of the internal request data stream functions into return async iterators. This blazes the trail for accepting async iterables in `body=`.
- Moved all tests related to file uploads into `test/with_dummyserver/async/`.
- Added `test/with_dummyserver/async_only/` for test cases that shouldn't be unasync-ed, things specific to an async library