### PR TITLE
Remove deprecated urllib3 features

### DIFF
--- a/src/ahip/__init__.py
+++ b/src/ahip/__init__.py
@@ -10,7 +10,6 @@ from .filepost import encode_multipart_formdata
 from .poolmanager import PoolManager, ProxyManager, proxy_from_url
 from .response import HTTPResponse
 from .util.request import make_headers
-from .util.url import get_host
 from .util.timeout import Timeout
 from .util.retry import Retry
 
@@ -35,7 +34,6 @@ __all__ = [
     "connection_from_url",
     "disable_warnings",
     "encode_multipart_formdata",
-    "get_host",
     "make_headers",
     "proxy_from_url",
 ]

--- a/src/ahip/connectionpool.py
+++ b/src/ahip/connectionpool.py
@@ -43,7 +43,6 @@ from .util.ssl_ import (
 )
 from .util.timeout import Timeout
 from .util.url import (
-    get_host,
     parse_url,
     Url,
     _normalize_host as normalize_host,
@@ -499,7 +498,10 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
             return True
 
         # TODO: Add optional support for socket.gethostbyname checking.
-        scheme, host, port = get_host(url)
+        url = parse_url(url)
+        scheme = url.scheme or "http"
+        host = url.hostname
+        port = url.port
         if host is not None:
             host = _normalize_host(host, scheme=scheme)
 
@@ -911,8 +913,11 @@ def connection_from_url(url, **kw):
         >>> conn = connection_from_url('http://google.com/')
         >>> r = conn.request('GET', '/')
     """
-    scheme, host, port = get_host(url)
-    port = port or DEFAULT_PORTS.get(scheme, 80)
+    url = parse_url(url)
+    scheme = url.scheme or "http"
+    host = url.hostname
+    port = url.port or DEFAULT_PORTS.get(scheme, 80)
+
     if scheme == "https":
         return HTTPSConnectionPool(host, port=port, **kw)
     else:

--- a/src/ahip/filepost.py
+++ b/src/ahip/filepost.py
@@ -42,24 +42,6 @@ def iter_field_objects(fields):
             yield RequestField.from_tuples(*field)
 
 
-def iter_fields(fields):
-    """
-    .. deprecated:: 1.6
-
-    Iterate over fields.
-
-    The addition of :class:`~hip.fields.RequestField` makes this function
-    obsolete. Instead, use :func:`iter_field_objects`, which returns
-    :class:`~hip.fields.RequestField` objects.
-
-    Supports list of (k, v) tuples and dicts.
-    """
-    if isinstance(fields, dict):
-        return ((k, v) for k, v in six.iteritems(fields))
-
-    return ((k, v) for k, v in fields)
-
-
 def encode_multipart_formdata(fields, boundary=None):
     """
     Encode a dictionary of ``fields`` using the multipart/form-data MIME format.

--- a/src/ahip/util/__init__.py
+++ b/src/ahip/util/__init__.py
@@ -19,7 +19,7 @@ from .ssl_ import (
 from .timeout import current_time, Timeout
 
 from .retry import Retry
-from .url import get_host, parse_url, split_first, Url
+from .url import parse_url, Url
 from .wait import wait_for_read, wait_for_write, wait_for_socket
 
 __all__ = (
@@ -34,12 +34,10 @@ __all__ = (
     "assert_fingerprint",
     "current_time",
     "is_connection_dropped",
-    "get_host",
     "parse_url",
     "make_headers",
     "resolve_cert_reqs",
     "resolve_ssl_version",
-    "split_first",
     "ssl_wrap_socket",
     "wait_for_read",
     "wait_for_write",

--- a/src/ahip/util/ssl_.py
+++ b/src/ahip/util/ssl_.py
@@ -37,8 +37,8 @@ def _const_compare_digest_backport(a, b):
     Returns True if the digests match, and False otherwise.
     """
     result = abs(len(a) - len(b))
-    for l, r in zip(bytearray(a), bytearray(b)):
-        result |= l ^ r
+    for left, right in zip(bytearray(a), bytearray(b)):
+        result |= left ^ right
     return result == 0
 
 

--- a/src/ahip/util/url.py
+++ b/src/ahip/util/url.py
@@ -172,41 +172,6 @@ class Url(namedtuple("Url", url_attrs)):
         return self.url
 
 
-def split_first(s, delims):
-    """
-    .. deprecated:: 1.25
-
-    Given a string and an iterable of delimiters, split on the first found
-    delimiter. Return two split parts and the matched delimiter.
-
-    If not found, then the first part is the full input string.
-
-    Example::
-
-        >>> split_first('foo/bar?baz', '?/=')
-        ('foo', 'bar?baz', '/')
-        >>> split_first('foo/bar?baz', '123')
-        ('foo/bar?baz', '', None)
-
-    Scales linearly with number of delims. Not ideal for large number of delims.
-    """
-    min_idx = None
-    min_delim = None
-    for d in delims:
-        idx = s.find(d)
-        if idx < 0:
-            continue
-
-        if min_idx is None or idx < min_idx:
-            min_idx = idx
-            min_delim = d
-
-    if min_idx is None or min_idx < 0:
-        return s, "", None
-
-    return s[:min_idx], s[min_idx + 1 :], min_delim
-
-
 def _encode_invalid_chars(component, allowed_chars, encoding="utf-8"):
     """Percent-encodes a URI component without reapplying
     onto an already percent-encoded component.
@@ -394,15 +359,9 @@ def parse_url(url):
     except (ValueError, AttributeError):
         return six.raise_from(LocationParseError(source_url), None)
 
-    # For the sake of backwards compatibility we put empty
-    # string values for path if there are any defined values
-    # beyond the path in the URL.
-    # TODO: Remove this when we break backwards compatibility.
+    # Replace empty strings with 'None'
     if not path:
-        if query is not None or fragment is not None:
-            path = ""
-        else:
-            path = None
+        path = None
 
     # Ensure that each part of the URL is a `str` for
     # backwards compatibility.
@@ -423,11 +382,3 @@ def parse_url(url):
         query=ensure_type(query),
         fragment=ensure_type(fragment),
     )
-
-
-def get_host(url):
-    """
-    Deprecated. Use :func:`parse_url` instead.
-    """
-    p = parse_url(url)
-    return p.scheme or "http", p.hostname, p.port

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -16,6 +16,7 @@ from dummyserver.server import (
 if sys.version_info[:2] < (3, 6):
     collect_ignore_glob = ["async/*.py", "with_dummyserver/async*/*.py"]
 
+
 # The Python 3.8+ default loop on Windows breaks Tornado
 @pytest.fixture(scope="session", autouse=True)
 def configure_windows_event_loop():

--- a/test/contrib/test_securetransport.py
+++ b/test/contrib/test_securetransport.py
@@ -33,13 +33,13 @@ def teardown_module():
 
 # SecureTransport does not support TLSv1.3
 # https://github.com/urllib3/urllib3/issues/1674
-from ..with_dummyserver.test_https import (  # noqa: F401
+from ..with_dummyserver.test_https import (  # noqa: E402, F401
     TestHTTPS,
     TestHTTPS_TLSv1,
     TestHTTPS_TLSv1_1,
     TestHTTPS_TLSv1_2,
 )
-from ..with_dummyserver.test_socketlevel import (  # noqa: F401
+from ..with_dummyserver.test_socketlevel import (  # noqa: E402, F401
     TestSNI,
     TestSocketClosing,
     TestClientCerts,

--- a/test/test_filepost.py
+++ b/test/test_filepost.py
@@ -1,25 +1,11 @@
 import pytest
 
-from hip.filepost import encode_multipart_formdata, iter_fields
+from hip.filepost import encode_multipart_formdata
 from hip.fields import RequestField
 from hip.packages.six import b, u
 
 
 BOUNDARY = "!! test boundary !!"
-
-
-class TestIterfields(object):
-    def test_dict(self):
-        for fieldname, value in iter_fields(dict(a="b")):
-            assert (fieldname, value) == ("a", "b")
-
-        assert list(sorted(iter_fields(dict(a="b", c="d")))) == [("a", "b"), ("c", "d")]
-
-    def test_tuple_list(self):
-        for fieldname, value in iter_fields([("a", "b")]):
-            assert (fieldname, value) == ("a", "b")
-
-        assert list(iter_fields([("a", "b"), ("c", "d")])) == [("a", "b"), ("c", "d")]
 
 
 class TestMultipartEncoding(object):


### PR DESCRIPTION
- Removes `hip.util.url.get_host()`
- Removes `hip.util.url.split_first()`
- Removes behavior where `path=""` is set depending on whether `query` or `fragment` are set.
  Now we always have `path=None` if `path=""`.
- Moved all `get_host()` test cases into `parse_url()` test suite
- Small lint fix (`l` and `r` -> `left` and `right`)