### PR TITLE
fixup async/await example after module rename #168 #213

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -60,14 +60,14 @@ It also supports async/await:
 
 .. code-block:: python
 
-    import hip
+    import ahip
     import trio
 
     async def main():
-        with hip.AsyncPoolManager() as http:
+        with ahip.PoolManager() as http:
             r = await http.request("GET", "http://httpbin.org/uuid")
             print("Status:", r.status)  # 200
-            print("Data:", await r.read()). # 'User-agent: *\nDisallow: /deny\n'
+            print("Data:", r.data) # 'User-agent: *\nDisallow: /deny\n'
 
     trio.run(main)
 


### PR DESCRIPTION
I noticed that the 'async/await example' in `README` no longer worked after the changes discussed in #168 were made in #213.
The module rename should be straightforward. However I also found that the return value of `await r.read()` was `b''` ie. no longer included the data received in the first exchange, which was a bit concerning. I changed the example to just read the `data` property, which works at least for small responses.

Perhaps awaiting `read()` is still required - and it is a bug that the prior data is not included in the return value, but I am not sure enough to open that as an issue. 