### PR TITLE
Default port calculation relies on the small integer cache

### DIFF
--- a/src/ahip/base.py
+++ b/src/ahip/base.py
@@ -67,7 +67,7 @@ class Request(object):
         if b"host" not in self.headers:
             # We test against a sentinel object here to forcibly always insert
             # the port for schemes we don't understand.
-            if port is DEFAULT_PORTS.get(scheme, object()):
+            if port == DEFAULT_PORTS.get(scheme, object()):
                 header = host
             else:
                 header = "{}:{}".format(host, port)

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -73,3 +73,19 @@ class TestConnection(object):
         assert body_bytes[1] in second_packet
         with pytest.raises(StopIteration):
             next(iterable)
+
+    def test_request_default_port_handling(self):
+        # Verify that the port is only included in the Host header when it
+        # is necessary.  In other words, when the specified port does not
+        # match the port for a KNOWN protocol
+        request = Request(method=b"GET", target="/")
+        request.add_host("httpbin.org", port=80, scheme="http")
+        assert request.headers["host"] == "httpbin.org"
+
+        request = Request(method=b"GET", target="/")
+        request.add_host("httpbin.org", port=443, scheme="https")
+        assert request.headers["host"] == "httpbin.org"
+
+        request = Request(method=b"GET", target="/")
+        request.add_host("httpbin.org", port=5672, scheme="amqp")
+        assert request.headers["host"] == "httpbin.org:5672"


### PR DESCRIPTION
The generation of the `Host` header in `Request` relies on the interpreter's small integer cache.  The [comparison between the request port and the default port](https://github.com/python-trio/hip/blob/cab5c4aacda54ea04b02ff2957589c78f169b690/src/ahip/base.py#L70) should be using equality instead of identity checking.